### PR TITLE
[JITERA] Update Health Check Route to /health2

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
   root to: 'frontend/home#index'
-  get 'ping', to: 'home#ping'
+  get 'health2', to: 'home#ping'
 
   post 'subscriptions', to: 'subscriptions#create'
 


### PR DESCRIPTION
# Overview
This pull request updates the health check endpoint from `/ping` to `/health2`. The new endpoint will point to the existing `ping` action in the `HomeController`.

# Changes
1. **Route Update**: 
   - The route in `config/routes.rb` has been modified to change the health check path from `/ping` to `/health2`. 
   - The new route is defined as `get 'health2', to: 'home#ping'`, which ensures that requests to `/health2` will still invoke the `ping` action in the `HomeController`.

2. **Old Route Consideration**: 
   - The old route for `/ping` has been removed in this update. If there is a requirement to keep it for backward compatibility, please let me know, and I can adjust accordingly.

This change is part of our effort to standardize health check endpoints across our services.
